### PR TITLE
該当のアイテム情報をDBから取り出し、クライアントに渡す処理を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ app.use(
   })
 );
 
+// サーバーが起動しているかチェックするため、パスを設定
 app.get("/", (req: Request, res: { send: (arg0: string) => void }) => {
   try {
     res.send("<div>hello</div>");
@@ -23,11 +24,11 @@ app.get("/", (req: Request, res: { send: (arg0: string) => void }) => {
   }
 });
 
+// メインページからのリクエストに対し、すべてのアイテム情報を返す処理
 app.get(
   "/getImgMainPage",
   (req: Request, res: { send: (arg0: string | number) => void }) => {
     try {
-      console.log(req);
       const columns: string[] = [
         "brand",
         "item_category",
@@ -40,9 +41,48 @@ app.get(
 
       const sql = `SELECT ${columns} FROM ${table}`;
 
-      db.query(sql, (err: string, result: string | number) => {
-        if (err) {
-          console.log(err);
+      db.query(sql, (error: string, result: string | number) => {
+        if (error) {
+          console.log(error);
+        } else {
+          res.send(result);
+        }
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+);
+
+// アイテムページからのリクエストに対し、該当するアイテムの詳細情報だけを返す処理
+app.get(
+  "/itemPage/:id",
+  (
+    req: { params: { id: number } },
+    res: { send: (arg0: string | number) => void }
+  ) => {
+    try {
+      const id = req.params.id;
+
+      const columns: string[] = [
+        "item_name",
+        "brand",
+        "item_category",
+        "item_info",
+        "item_url",
+        "item_img_url",
+        "instagram_embed_code",
+      ];
+
+      const table: string = "items_info";
+
+      const joinTable: string = " instagram_items_info";
+
+      const sql = `SELECT ${columns} FROM ${table} INNER JOIN ${joinTable} ON ${table}.item_id = ${joinTable}.item_id WHERE ${joinTable}.item_id = ?`;
+
+      db.query(sql, [id], (error: string, result: string | number) => {
+        if (error) {
+          console.log(error);
         } else {
           res.send(result);
         }


### PR DESCRIPTION
▼処理の概要
指定されたテーブルから該当のアイテム情報をDBから取り出し、クライアントに渡す処理を追加した。

▼Issues
https://github.com/Shin-Goz-Maeda/related-item-ver2-server/issues/3